### PR TITLE
Remove color mode of a page

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <PDFDoc.h>
 #include <PDFDocFactory.h>
-#include <PreScanOutputDev.h>
 #include <Annot.h>
 #include <FontInfo.h>
 #include <GlobalParams.h>

--- a/main.cc
+++ b/main.cc
@@ -238,22 +238,6 @@ namespace {
       json.EndArray();
     }
 
-    {
-      PreScanOutputDev *scan = new PreScanOutputDev(doc);
-      page->display(scan, 72, 72, 0, gTrue, gFalse, gFalse);
-
-      json.Key("is_monochrome");
-      json.Bool(scan->isMonochrome() ? true : false);
-
-      json.Key("is_grayscale");
-      json.Bool(scan->isGray() ? true : false);
-
-      json.Key("is_transparent");
-      json.Bool(scan->usesTransparency() ? true : false);
-
-      delete scan;
-    }
-
     json.Key("number_of_annotations");
     json.Int(page->getAnnots()->getNumAnnots());
 

--- a/main.cc
+++ b/main.cc
@@ -213,7 +213,7 @@ namespace {
   }
 
   template <typename JSON>
-  void write_page(JSON &json, PDFDoc *doc, Page *page) {
+  void write_page(JSON &json, Page *page) {
     json.StartObject();
 
     json.Key("page_number");
@@ -309,7 +309,7 @@ namespace {
     json.Key("pages");
     json.StartArray();
     for (int i = 1, last = doc->getNumPages(); i <= last; ++i) {
-      write_page(json, doc, doc->getPage(i));
+      write_page(json, doc->getPage(i));
     }
     json.EndArray();
 

--- a/main.cc
+++ b/main.cc
@@ -279,7 +279,7 @@ namespace {
 
   template <typename JSON>
   void write_json(JSON &json, PDFDoc *doc) {
-    // Prefetch FontInfo objects because PreScanOutputDev modifies data for fonts sometimes
+    // Prefetch FontInfo objects because ImageListDev modifies data for fonts depending on the file
     GooList *fonts = scanFonts(doc);
 
     json.StartObject();

--- a/test/data-blank-stdout.txt
+++ b/test/data-blank-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 841.89
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-stdout.txt
+++ b/test/data-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-tagged-stdout.txt
+++ b/test/data-tagged-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 841.92
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-unembedded-fonts-stdout.txt
+++ b/test/data-unembedded-fonts-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-with-annotations-stdout.txt
+++ b/test/data-with-annotations-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": false,
-            "is_grayscale": false,
-            "is_transparent": true,
             "number_of_annotations": 2
         }
     ],

--- a/test/data-with-form-stdout.txt
+++ b/test/data-with-form-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": false,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 3
         }
     ],

--- a/test/data-with-image-stdout.txt
+++ b/test/data-with-image-stdout.txt
@@ -44,9 +44,6 @@
                     }
                 }
             ],
-            "is_monochrome": false,
-            "is_grayscale": false,
-            "is_transparent": true,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-with-indexed-image-stdout.txt
+++ b/test/data-with-indexed-image-stdout.txt
@@ -37,9 +37,6 @@
                     }
                 }
             ],
-            "is_monochrome": false,
-            "is_grayscale": false,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-with-javascript-stdout.txt
+++ b/test/data-with-javascript-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-with-password-stdout.txt
+++ b/test/data-with-password-stdout.txt
@@ -21,9 +21,6 @@
                 "height": 824.8820599999999
             },
             "images": [],
-            "is_monochrome": true,
-            "is_grayscale": true,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],

--- a/test/data-with-stencil-image-stdout.txt
+++ b/test/data-with-stencil-image-stdout.txt
@@ -29,9 +29,6 @@
                     "ppi_y": 72.0
                 }
             ],
-            "is_monochrome": false,
-            "is_grayscale": false,
-            "is_transparent": false,
             "number_of_annotations": 0
         }
     ],


### PR DESCRIPTION
`PreScanOutputDev` isn't perfect to detect color mode of a page.